### PR TITLE
Fix broken SVG serialization for `SVGCircle`

### DIFF
--- a/Source/Model/Shapes/SVGEllipse.swift
+++ b/Source/Model/Shapes/SVGEllipse.swift
@@ -20,10 +20,10 @@ public class SVGEllipse: SVGShape, ObservableObject {
     }
 
     override public func serialize(_ serializer: Serializer) {
-        serializer.add("cx", cx.description, "0")
-            .add("cy", cy.description, "0")
-            .add("rx", rx.description, "0")
-            .add("ry", ry.description, "0")
+        serializer.add("cx", cx, 0)
+            .add("cy", cy, 0)
+            .add("rx", rx, 0)
+            .add("ry", ry, 0)
         super.serialize(serializer)
     }
 

--- a/Source/Serialization/Serializer.swift
+++ b/Source/Serialization/Serializer.swift
@@ -92,7 +92,7 @@ public class Serializer {
 
     @discardableResult func add<S>(_ key: String, _ value: S, _ defVal: S) -> Serializer where S: SerializableAtom, S: Equatable {
         if (value != defVal) {
-            add(key: key, block: value.serialize())
+            add(key: key, block: "\"\(value.serialize())\"")
         }
         return self
     }


### PR DESCRIPTION
`SVGCircle` calls `Serializer.add<S>(key:value:defVal)` with `CGFloat` values. This led to serialization of the numeric values _without wrapping them in quotes_, which resulted in an invalid SVG output. `SVGEllipse` avoided this fate by serializing its own numeric values _after_ converting them to strings, which calls the slightly different function `Serializer.add<S: SerializableOption>(_ key: String, _ value: S)` which _does_ wrap its arguments in quotes. So my thinking here was to (a) wrap everything in quotes and (b) unify `SVGCircle` and `SVGEllipse` to go through the same codepath. Things are looking good in the app so let's ship it!